### PR TITLE
[IOPID-1224] : Removing minimum spidLevel for session-state

### DIFF
--- a/SessionState/__test__/handler.test.ts
+++ b/SessionState/__test__/handler.test.ts
@@ -1,7 +1,6 @@
 import * as E from "fp-ts/lib/Either";
 import { aValidExchangeUser, aValidL2User } from "../../__mocks__/users";
 import { Client } from "../../generated/definitions/fast-login/client";
-import { SpidLevel } from "../../utils/enums/SpidLevels";
 import { HslJwtPayloadExtended } from "../../utils/middlewares/hsl-jwt-validation-middleware";
 import { sessionStateHandler } from "../handler";
 
@@ -23,11 +22,6 @@ const sessionStateMock = jest.fn(async () =>
 const sessionStateClientMock = ({
   getUserSessionState: sessionStateMock
 } as unknown) as Client<"ApiKeyAuth">;
-
-const aL1User: HslJwtPayloadExtended = {
-  ...aValidL2User,
-  spid_level: SpidLevel.L1
-};
 
 const emptySessionState = {
   access_enabled: false,
@@ -63,12 +57,12 @@ describe("SessionState", () => {
     }
   );
 
-  test(`GIVEN a valid user decoded from JWT
+  test(`GIVEN an invalid JWT
         WHEN checks don't pass
         THEN the response is 403`, async () => {
     const handler = sessionStateHandler(sessionStateClientMock);
 
-    const res = await handler(aL1User);
+    const res = await handler(("" as unknown) as HslJwtPayloadExtended);
 
     expect(sessionStateMock).toHaveBeenCalledTimes(0);
     expect(res).toMatchObject({

--- a/SessionState/__test__/handler.test.ts
+++ b/SessionState/__test__/handler.test.ts
@@ -1,7 +1,6 @@
 import * as E from "fp-ts/lib/Either";
 import { aValidExchangeUser, aValidL2User } from "../../__mocks__/users";
 import { Client } from "../../generated/definitions/fast-login/client";
-import { HslJwtPayloadExtended } from "../../utils/middlewares/hsl-jwt-validation-middleware";
 import { sessionStateHandler } from "../handler";
 
 // #region mocks
@@ -56,19 +55,6 @@ describe("SessionState", () => {
       });
     }
   );
-
-  test(`GIVEN an invalid JWT
-        WHEN checks don't pass
-        THEN the response is 403`, async () => {
-    const handler = sessionStateHandler(sessionStateClientMock);
-
-    const res = await handler(("" as unknown) as HslJwtPayloadExtended);
-
-    expect(sessionStateMock).toHaveBeenCalledTimes(0);
-    expect(res).toMatchObject({
-      kind: "IResponseErrorForbiddenNotAuthorized"
-    });
-  });
 
   test(`GIVEN a valid user decoded from JWT
     WHEN the client returns an error

--- a/SessionState/handler.ts
+++ b/SessionState/handler.ts
@@ -26,7 +26,7 @@ import { SequenceMiddleware } from "@pagopa/ts-commons/lib/sequence_middleware";
 import { defaultLog } from "@pagopa/winston-ts";
 
 import { IConfig } from "../utils/config";
-import { SpidLevel, gte } from "../utils/enums/SpidLevels";
+import { SpidLevel } from "../utils/enums/SpidLevels";
 import { TokenTypes } from "../utils/enums/TokenTypes";
 import { verifyUserEligibilityMiddleware } from "../utils/middlewares/user-eligibility-middleware";
 import {
@@ -58,7 +58,7 @@ const canSeeProfile = (
 ): boolean =>
   (ExchangeJwtPayloadExtended.is(user) &&
     user.token_type === TokenTypes.EXCHANGE) ||
-  (HslJwtPayloadExtended.is(user) && gte(user.spid_level, SpidLevel.L2));
+  HslJwtPayloadExtended.is(user);
 
 export const sessionStateHandler = (
   client: SessionStateClient


### PR DESCRIPTION
The purpose of this PR is to resolve issue [1224](https://pagopa.atlassian.net/browse/IOPID-1224).  The error is related to the fact that when logging in with L1 (to log out the user from the IO session), the session-state api is called to check for active sessions.

In the handler of the session state, it checks that the requested SPID was > L1, resulting in a 403 error.

#### List of Changes
The modification involves removing this check, allowing the calling of this endpoint at any SPID level, and resolving the issue

#### How Has This Been Tested?
Locally with postman

