### PR TITLE
[IOPID-1375] : Adding IP on AudtiLog tag

### DIFF
--- a/Exchange/handler.ts
+++ b/Exchange/handler.ts
@@ -99,6 +99,7 @@ export const exchangeHandler = (
               FatherIDToken: user_data.jti,
               FiscalCode: hashFiscalCode(decodedToken.fiscal_number),
               IDToken: decodedToken.jti,
+              Ip: O.getOrElse(() => "UNKNOWN")(maybeClientIp),
               Type: TokenTypes.EXCHANGE
             }
           )

--- a/utils/audit-log.ts
+++ b/utils/audit-log.ts
@@ -38,6 +38,7 @@ const AuditLogTags = t.type({
   FatherIDToken: t.string,
   FiscalCode: t.string,
   IDToken: t.string,
+  Ip: t.string,
   Type: t.keyof({ [TokenTypes.EXCHANGE]: null })
 });
 

--- a/utils/middlewares/__tests__/audit-log.test.ts
+++ b/utils/middlewares/__tests__/audit-log.test.ts
@@ -23,6 +23,7 @@ describe('Audit Logs Utils' , () => {
     FiscalCode: '12345678901' as FiscalCode,
     DateTime: '2022-01-01T12:00:00Z',
     IDToken: 'token123',
+    Ip: '127.0.0.1',
     Type: 'exchange' as TokenTypes,
   };
 


### PR DESCRIPTION
In this PR, we are adding the IP address information to the tag when storing audit logs on the Exchange API, as requested in the [Jira task.](https://pagopa.atlassian.net/browse/IOPID-1375)